### PR TITLE
Convert file format

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -4,7 +4,7 @@ import "./DLL.sol";
 import "./AttributeStore.sol";
 
 /**
-@title Partial-Lock-Commit-Reveal Voting scheme with ERC20 tokens 
+@title Partial-Lock-Commit-Reveal Voting scheme with ERC20 tokens
 @author Team: Aspyn Palatnick, Cem Ozer, Yorke Rhodes
 */
 contract PLCRVoting {
@@ -26,7 +26,7 @@ contract PLCRVoting {
         uint votesFor;		    /// tally of votes supporting proposal
         uint votesAgainst;      /// tally of votes countering proposal
     }
-    
+
     /// maps pollID to Poll struct
     mapping(uint => Poll) public pollMap;
     uint pollNonce;
@@ -57,7 +57,7 @@ contract PLCRVoting {
     // TOKEN INTERFACE:
     // ================
 
-    /**    
+    /**
     @notice Loads _numTokens ERC20 tokens into the voting contract for one-to-one voting rights
     @dev Assumes that msg.sender has approved voting contract to spend on their behalf
     @param _numTokens The number of votingTokens desired in exchange for ERC20 tokens
@@ -101,7 +101,7 @@ contract PLCRVoting {
     @param _pollID Integer identifier associated with target poll
     @param _secretHash Commit keccak256 hash of voter's choice and salt (tightly packed in this order)
     @param _numTokens The number of tokens to be committed towards the target poll
-    @param _prevPollID The ID of the poll that the user has voted the maximum number of tokens in which is still less than or equal to numTokens 
+    @param _prevPollID The ID of the poll that the user has voted the maximum number of tokens in which is still less than or equal to numTokens
     */
     function commitVote(uint _pollID, bytes32 _secretHash, uint _numTokens, uint _prevPollID) external {
         require(commitPeriodActive(_pollID));
@@ -139,7 +139,7 @@ contract PLCRVoting {
     function validPosition(uint _prevID, uint _nextID, address _voter, uint _numTokens) public constant returns (bool valid) {
         bool prevValid = (_numTokens >= getNumTokens(_voter, _prevID));
         // if next is zero node, _numTokens does not need to be greater
-        bool nextValid = (_numTokens <= getNumTokens(_voter, _nextID) || _nextID == 0); 
+        bool nextValid = (_numTokens <= getNumTokens(_voter, _nextID) || _nextID == 0);
         return prevValid && nextValid;
     }
 
@@ -155,13 +155,13 @@ contract PLCRVoting {
         require(!hasBeenRevealed(msg.sender, _pollID));                        // prevent user from revealing multiple times
         require(sha3(_voteOption, _salt) == getCommitHash(msg.sender, _pollID)); // compare resultant hash from inputs to original commitHash
 
-        uint numTokens = getNumTokens(msg.sender, _pollID); 
+        uint numTokens = getNumTokens(msg.sender, _pollID);
 
         if (_voteOption == 1) // apply numTokens to appropriate poll choice
             pollMap[_pollID].votesFor += numTokens;
         else
             pollMap[_pollID].votesAgainst += numTokens;
-        
+
         dllMap[msg.sender].remove(_pollID); // remove the node referring to this vote upon reveal
 
         VoteRevealed(msg.sender, _pollID, numTokens, _voteOption);
@@ -185,7 +185,7 @@ contract PLCRVoting {
 
     // ==================
     // POLLING INTERFACE:
-    // ================== 
+    // ==================
 
     /**
     @dev Initiates a poll with canonical configured parameters at pollID emitted by PollCreated event
@@ -207,7 +207,7 @@ contract PLCRVoting {
         PollCreated(_voteQuorum, _commitDuration, _revealDuration, pollNonce);
         return pollNonce;
     }
- 
+
     /**
     @notice Determines if proposal has passed
     @dev Check if votesFor out of totalVotes exceeds votesQuorum (requires pollEnded)
@@ -311,11 +311,11 @@ contract PLCRVoting {
     @dev Gets the bytes32 commitHash property of target poll
     @param _voter Address of user to check against
     @param _pollID Integer identifier associated with target poll
-    @return Bytes32 hash property attached to target poll 
+    @return Bytes32 hash property attached to target poll
     */
-    function getCommitHash(address _voter, uint _pollID) constant public returns (bytes32 commitHash) { 
-        return bytes32(store.getAttribute(attrUUID(_voter, _pollID), "commitHash"));    
-    } 
+    function getCommitHash(address _voter, uint _pollID) constant public returns (bytes32 commitHash) {
+        return bytes32(store.getAttribute(attrUUID(_voter, _pollID), "commitHash"));
+    }
 
     /**
     @dev Wrapper for getAttribute with attrName="numTokens"
@@ -339,7 +339,7 @@ contract PLCRVoting {
     /**
     @dev Gets the numTokens property of getLastNode
     @param _voter Address of user to check against
-    @return Maximum number of tokens committed in poll specified 
+    @return Maximum number of tokens committed in poll specified
     */
     function getLockedTokens(address _voter) constant public returns (uint numTokens) {
         return getNumTokens(_voter, getLastNode(_voter));
@@ -366,7 +366,7 @@ contract PLCRVoting {
 
       return nodeID;
     }
- 
+
     // ----------------
     // GENERAL HELPERS:
     // ----------------


### PR DESCRIPTION
Fixes #3 

- Convert `PLCRVoting.sol` to unix file format
- Cleanup: spacing