### PR TITLE
Fix integer overflows in PLCRVoting.startPoll

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -203,12 +203,21 @@ contract PLCRVoting {
     @param _revealDuration Length of desired reveal period in seconds
     */
     function startPoll(uint _voteQuorum, uint _commitDuration, uint _revealDuration) public returns (uint pollID) {
+        require(_voteQuorum <= 100);
+        
+        uint commitEndDate = block.timestamp + _commitDuration;
+        uint revealEndDate = commitEndDate + _revealDuration;
+        
+        // Prevent overflows
+        require(commitEndDate >= block.timestamp);
+        require(revealEndDate >= commitEndDate);
+        
         pollNonce = pollNonce + 1;
 
         pollMap[pollNonce] = Poll({
             voteQuorum: _voteQuorum,
-            commitEndDate: block.timestamp + _commitDuration,
-            revealEndDate: block.timestamp + _commitDuration + _revealDuration,
+            commitEndDate: commitEndDate,
+            revealEndDate: revealEndDate,
             votesFor: 0,
             votesAgainst: 0
         });

--- a/test/startPoll.js
+++ b/test/startPoll.js
@@ -1,12 +1,35 @@
 /* eslint-env mocha */
-/* global contract */
+/* global contract assert */
 
-contract('PLCRVoting', () => {
+const utils = require('./utils.js');
+const BN = require('bignumber.js');
+
+const bigTen = number => new BN(number.toString(10), 10);
+const maxUint = bigTen(2).toPower(256).minus(1);
+
+contract('PLCRVoting', (accounts) => {
   describe('Function: startPoll', () => {
+    const [alice] = accounts;
+
     it('should return a poll with ID 1 for the first poll created');
     it('should return a poll with ID 5 for the fifth poll created');
     it('should create a poll with a 50% vote quorum and 100 second commit/reveal durations');
     it('should create a poll with a 60% vote quorum, a 100 second commit duration and ' +
        'a 200 second reveal duration');
+
+    it('should not start poll with commitDuration that causes uint overflow', async () => {
+      const plcr = await utils.getPLCRInstance();
+
+      const voteQuorum = bigTen(50);
+      const commitDuration = maxUint;
+      const revealDuration = bigTen(600);
+
+      try {
+        await utils.as(alice, plcr.startPoll, voteQuorum, commitDuration, revealDuration);
+        assert(false, 'Alice was able to start a poll with commitDuration that causes uint overflow');
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+      }
+    });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -100,9 +100,17 @@ const utils = {
     return fn(...args, sendObject);
   },
 
-  isEVMException(err) {
-    return err.toString().includes('invalid opcode');
-  },
+  isEVMException: err => (
+    utils.isInvalidOpcode(err) || utils.isRevert(err)
+  ),
+
+  isInvalidOpcode: err => (
+    err.toString().includes('invalid opcode')
+  ),
+
+  isRevert: err => (
+    err.toString().includes('revert')
+  ),
 
   startPollAndCommitVote: async (options) => {
     if (


### PR DESCRIPTION
Integer overflows in startPoll allow creating a poll with 

- 0 commitEndDate and 0 revealEndDate: this results in pollExists returning false
- 0 for commitEndDate but not revealEndDate and visa versa: this results in pollExists to throw an assertion
- revealEndDate earlier than commitEndDate
- commitEndDate or revealEndDate in the past

As part of this commit:
- Validation for voteQuorum <=100 added