### PR TITLE
Make PLCRVoting usable as a template contract

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -38,6 +38,8 @@ contract PLCRVoting {
     // STATE VARIABLES:
     // ============
 
+    PLCRVoting masterCopy; // THIS MUST ALWAYS BE THE FIRST STATE VARIABLE DECLARED!!!!!!
+
     uint constant public INITIAL_POLL_NONCE = 0;
     uint public pollNonce;
 

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -54,10 +54,21 @@ contract PLCRVoting {
     // ============
 
     /**
-    @dev Initializes voteQuorum, commitDuration, revealDuration, and pollNonce in addition to token contract and trusted mapping
-    @param _tokenAddr The address where the ERC20 token contract is deployed
+    @dev uses the setup function to initialize PLCR by specifying the token used for voting
+    @param _tokenAddr The address of the ERC20 token to be used for voting
     */
     function PLCRVoting(address _tokenAddr) public {
+        setup(_tokenAddr);
+    }
+
+    /**
+    @dev initializes the contract by spcifying the token used for voting. Can be called by proxy
+    contracts to initialize their state.
+    @param _tokenAddr The address of the ERC20 token to be used for voting
+    */
+    function setup(address _tokenAddr) public {
+        require(address(token) == 0);
+
         token = EIP20(_tokenAddr);
         pollNonce = INITIAL_POLL_NONCE;
     }


### PR DESCRIPTION
This should enable PLCRVoting's use as a template contract to proxies, as in the [Gnosis Safe](https://github.com/gnosis/gnosis-safe-contracts).

It factors storage initialization out of the constructor and into a `setup` function, and reserves the first storage slot.