### PR TITLE
Add test coverage and make related changes to contract

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -336,7 +336,10 @@ contract PLCRVoting {
     @return Bytes32 hash property attached to target poll 
     */
     function getCommitHash(address _voter, uint _pollID) constant public returns (bytes32 commitHash) { 
-        return bytes32(store.getAttribute(attrUUID(_voter, _pollID), "commitHash"));    
+        bytes32 hash = bytes32(store.getAttribute(attrUUID(_voter, _pollID), "commitHash"));
+        // Assuming the hash cannot accidentally be 0
+        require(hash != 0);
+        return hash;
     } 
 
     /**

--- a/test/getCommitHash.js
+++ b/test/getCommitHash.js
@@ -1,9 +1,26 @@
 /* eslint-env mocha */
 /* global contract */
 
-contract('PLCRVoting', () => {
+const utils = require('./utils.js');
+
+contract('PLCRVoting', (accounts) => {
   describe('Function: getCommitHash', () => {
-    it('should return the commit hash stored by the voter for some pollID');
+    const [alice] = accounts;
+
+    it('should return the commit hash stored by the voter for some pollID',
+      async () => {
+        const errMsg = 'Alice could not retreive the correct commit hash';
+        const plcr = await utils.getPLCRInstance();
+        const options = utils.defaultOptions();
+        options.actor = alice;
+
+        const pollID = await utils.startPollAndCommitVote(options);
+        const secretHash = utils.createVoteHash(options.vote, options.salt);
+
+        const retreivedHash = await plcr.getCommitHash.call(options.actor, pollID);
+        assert.strictEqual(secretHash, retreivedHash, errMsg);
+    });
+
     it('should fail if the user has not stored any commit hash for some pollID');
   });
 });

--- a/test/getCommitHash.js
+++ b/test/getCommitHash.js
@@ -5,7 +5,7 @@ const utils = require('./utils.js');
 
 contract('PLCRVoting', (accounts) => {
   describe('Function: getCommitHash', () => {
-    const [alice] = accounts;
+    const [alice, bob] = accounts;
 
     it('should return the commit hash stored by the voter for some pollID',
       async () => {
@@ -21,7 +21,26 @@ contract('PLCRVoting', (accounts) => {
         assert.strictEqual(secretHash, retreivedHash, errMsg);
     });
 
-    it('should fail if the user has not stored any commit hash for some pollID');
+    it('should fail if the user has not stored any commit hash for some pollID',
+      async () => {
+        const errMsg = 'Bob was able to retreive a commit hash although he had not committed any vote';
+        const plcr = await utils.getPLCRInstance();
+        const options = utils.defaultOptions();
+
+        // Start poll and commit vote as Alice
+        options.actor = alice;
+        const pollID = await utils.startPollAndCommitVote(options);
+
+        try {
+          // try to get commit hash for Bob
+          options.actor = bob;
+          const retreivedHash = await plcr.getCommitHash.call(options.actor, pollID);
+          assert(false, errMsg);
+        } catch (err) {
+          assert(utils.isEVMException(err), err.toString());
+          return;
+        }
+    });
   });
 });
 

--- a/test/getLastNode.js
+++ b/test/getLastNode.js
@@ -1,9 +1,45 @@
 /* eslint-env mocha */
 /* global contract */
 
-contract('PLCRVoting', () => {
+const utils = require('./utils.js');
+
+contract('PLCRVoting', (accounts) => {
   describe('Function: getLastNode', () => {
-    it('should return the poll for which the user has the greatest number of tokens committed');
+    const [alice] = accounts;
+
+    it('should return the poll for which the user has the greatest number of tokens committed',
+      async () => {
+        const errMsg = 'Alice could not retreive the correct last node';
+        const plcr = await utils.getPLCRInstance();
+        const options = utils.defaultOptions();
+        options.actor = alice;
+
+        let retreivedPollID;
+        let highestVotePollID;
+
+        // Alice commits only to one poll and retreives that node
+        options.numTokens = '10';
+        highestVotePollID = await utils.startPollAndCommitVote(options);
+        retreivedPollID = await plcr.getLastNode.call(options.actor);
+        assert.strictEqual(highestVotePollID.toString(10),
+                           retreivedPollID.toString(10),
+                           errMsg);
+
+        // Alice commits to another poll but with less tokens than his first time
+        options.numTokens = '5';
+        await utils.startPollAndCommitVote(options);
+        retreivedPollID = await plcr.getLastNode.call(options.actor);
+        assert.strictEqual(highestVotePollID.toString(10),
+                           retreivedPollID.toString(10),
+                           errMsg);
+
+        // Alice commits to another poll but with more tokens than his first time
+        options.numTokens = '20';
+        highestVotePollID = await utils.startPollAndCommitVote(options);
+        retreivedPollID = await plcr.getLastNode.call(options.actor);
+        assert.strictEqual(highestVotePollID.toString(10),
+                           retreivedPollID.toString(10),
+                           errMsg);
+    });
   });
 });
-


### PR DESCRIPTION
Added test coverage to getCommitHash and getLastNode.

When testing the failure case for getCommitHash I noticed that getCommitHash actually did not fail as described in its pending test coverage. Thus, I've also made a small change to getCommitHash for it to fail when called upon to retrieve a hash that was not submitted in the first place.
