### PR TITLE
Add tests to exhibit pollID bug

### DIFF
--- a/test/getInsertPointForNumTokens.js
+++ b/test/getInsertPointForNumTokens.js
@@ -1,11 +1,37 @@
 /* eslint-env mocha */
 /* global contract assert */
 
+const BN = require('bignumber.js');
 const utils = require('./utils.js');
 
 contract('PLCRVoting', (accounts) => {
   describe('Function: getInsertPointForNumTokens', () => {
-    const [alice] = accounts;
+    const [alice, bob] = accounts;
+
+    it('should return the correct insert point when increasing the num tokens', async () => {
+      const plcr = await utils.getPLCRInstance();
+
+      // options 1
+      const options = utils.defaultOptions();
+      options.actor = bob;
+      options.numTokens = '20';
+      options.votingRights = '100';
+
+      // grab the first prevPollID
+      const prevPollID1 = await plcr.getInsertPointForNumTokens.call(bob, options.numTokens);
+      // make sure it's 1
+      assert.strictEqual(prevPollID1.toString(), '0', 'prevPollID should be zero because this is the first poll');
+
+      // start poll, commit vote
+      await utils.startPollAndCommitVote(options);
+
+      const increasedNumTokens = new BN(options.numTokens).add('1').toString();
+      // grab the second prevPollID
+      const prevPollID2 = await plcr.getInsertPointForNumTokens.call(bob, increasedNumTokens);
+      // make sure it's 2 (since numTokens is greater this time)
+      assert.strictEqual(prevPollID2.toString(), '1',
+        'should have returned 1 because numTokens is greater than numTokens in node 1, which the only node besides 0');
+    });
 
     it('should return the correct insert point for a new node in a DLL', async () => {
       // Create { A: 1, B: 5, C: 10 }
@@ -68,4 +94,3 @@ contract('PLCRVoting', (accounts) => {
     });
   });
 });
-

--- a/test/hasBeenRevealed.js
+++ b/test/hasBeenRevealed.js
@@ -17,7 +17,7 @@ contract('PLCRVoting', (accounts) => {
       }
     });
     it('should return true if the user has already revealed for this poll');
-    it('should return false if the user has not revealed for this poll');
+    it('should return false if the user has not revealed for this poll, even if it is expired');
     it('should return false if the user never commit-voted in this poll', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();

--- a/test/hasBeenRevealed.js
+++ b/test/hasBeenRevealed.js
@@ -17,7 +17,7 @@ contract('PLCRVoting', (accounts) => {
       }
     });
     it('should return true if the user has already revealed for this poll');
-    it('should return false if the user has not revealed for this poll, even if it is expired');
+    it('should return false if the user has not revealed for this poll');
     it('should return false if the user never commit-voted in this poll', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();


### PR DESCRIPTION
This bug was initially found here:
https://github.com/skmgoldin/tcr/pull/40

This branch contains 2 tests -- one for `commitVote`, the other for `getInsertPointForNumTokens`. They aren't perfectly explicit, but they're simple and they demonstrate how it is actually during `commitVote` that we experience the bug, and **not** `getInsertPointForNumTokens`:
https://github.com/ConsenSys/PLCRVoting/commits/pollID-bug