### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tokenPLCRvoting",
+  "name": "plcrvoting",
   "version": "0.0.1",
   "description": "Voting smart contract system for use with ERC20 tokens",
   "scripts": {


### PR DESCRIPTION
It is currently difficult to depend on this project by importing them into solidity.

I don't understand how it came to be that the name of the repo is different for `npm` vs. `ethpm` but since one of those package-managers is on an immutable _blockchain_, I figure it is less disruptive to change this one.

With the proposed change I would be able to write my Solidity code compatible with importing it using `npm` or `ethpm`.