### PR TITLE
Add getter functions: didCommit & didReveal

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -294,6 +294,30 @@ contract PLCRVoting {
     }
 
     /**
+    @dev Checks if user has committed for specified poll
+    @param _voter Address of user to check against
+    @param _pollID Integer identifier associated with target poll
+    @return Boolean indication of whether user has committed
+    */
+    function didCommit(address _voter, uint _pollID) constant public returns (bool committed) {
+        require(pollExists(_pollID));
+
+        return pollMap[_pollID].didCommit[_voter];
+    }
+
+    /**
+    @dev Checks if user has revealed for specified poll
+    @param _voter Address of user to check against
+    @param _pollID Integer identifier associated with target poll
+    @return Boolean indication of whether user has revealed
+    */
+    function didReveal(address _voter, uint _pollID) constant public returns (bool revealed) {
+        require(pollExists(_pollID));
+
+        return pollMap[_pollID].didReveal[_voter];
+    }
+
+    /**
     @dev Checks if a poll exists
     @param _pollID The pollID whose existance is to be evaluated.
     @return Boolean Indicates whether a poll exists for the provided pollID

--- a/test/didCommit.js
+++ b/test/didCommit.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+/* global contract assert */
+
+const utils = require('./utils.js');
+
+contract('PLCRVoting', (accounts) => {
+  describe('Function: didCommit', () => {
+    const [alice, bob] = accounts;
+
+    it('should return true for a poll that a voter has committed', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+
+      // didCommit(alice, pollID)
+      const actual = await plcr.didCommit.call(options.actor, pollID.toString());
+      const expected = true;
+      assert.strictEqual(actual, expected, 'should have returned true because alice DID commit');
+    });
+
+    it('should return false for a poll that a voter did not commit', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+
+      // didCommit(bob, pollID)
+      const actual = await plcr.didCommit.call(bob, pollID.toString());
+      const expected = false;
+      assert.strictEqual(actual, expected, 'should have returned false because bob did NOT commit');
+    });
+
+    it('should revert for a poll that doesnt exist', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+
+      try {
+        // didCommit(alice, pollID + 420420420)
+        await plcr.didCommit.call(options.actor, pollID.add('420420420').toString());
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+        return;
+      }
+      assert(false, 'should not have been able to successfully call didCommit because the poll doesnt exists');
+    });
+  });
+});

--- a/test/didCommit.js
+++ b/test/didCommit.js
@@ -5,14 +5,14 @@ const utils = require('./utils.js');
 
 contract('PLCRVoting', (accounts) => {
   describe('Function: didCommit', () => {
-    const [alice, bob] = accounts;
+    const [alice] = accounts;
 
     it('should return true for a poll that a voter has committed', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();
       options.actor = alice;
 
-      // alice commits
+      // alice starts poll & commits
       const pollID = await utils.startPollAndCommitVote(options);
 
       // didCommit(alice, pollID)
@@ -24,28 +24,24 @@ contract('PLCRVoting', (accounts) => {
     it('should return false for a poll that a voter did not commit', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();
-      options.actor = alice;
 
-      // alice commits
-      const pollID = await utils.startPollAndCommitVote(options);
+      // start poll
+      const receipt = await plcr.startPoll(options.quorum,
+        options.commitPeriod, options.revealPeriod);
+      const pollID = utils.getPollIDFromReceipt(receipt);
 
-      // didCommit(bob, pollID)
-      const actual = await plcr.didCommit.call(bob, pollID.toString());
+      // didCommit(alice, pollID)
+      const actual = await plcr.didCommit.call(alice, pollID.toString());
       const expected = false;
-      assert.strictEqual(actual, expected, 'should have returned false because bob did NOT commit');
+      assert.strictEqual(actual, expected, 'should have returned false because alice did NOT commit');
     });
 
     it('should revert for a poll that doesnt exist', async () => {
       const plcr = await utils.getPLCRInstance();
-      const options = utils.defaultOptions();
-      options.actor = alice;
-
-      // alice commits
-      const pollID = await utils.startPollAndCommitVote(options);
 
       try {
-        // didCommit(alice, pollID + 420420420)
-        await plcr.didCommit.call(options.actor, pollID.add('420420420').toString());
+        // didCommit(alice, 420420420)
+        await plcr.didCommit.call(alice, '420420420');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
         return;

--- a/test/didReveal.js
+++ b/test/didReveal.js
@@ -6,14 +6,14 @@ const BN = require('bignumber.js');
 
 contract('PLCRVoting', (accounts) => {
   describe('Function: didReveal', () => {
-    const [alice, bob] = accounts;
+    const [alice] = accounts;
 
     it('should return true for a poll that a voter has revealed', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();
       options.actor = alice;
 
-      // alice commits
+      // alice starts poll & commits
       const pollID = await utils.startPollAndCommitVote(options);
       await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
 
@@ -31,7 +31,7 @@ contract('PLCRVoting', (accounts) => {
       const options = utils.defaultOptions();
       options.actor = alice;
 
-      // alice commits
+      // alice starts poll & commits
       const pollID = await utils.startPollAndCommitVote(options);
 
       // didReveal(alice, pollID)
@@ -40,39 +40,27 @@ contract('PLCRVoting', (accounts) => {
       assert.strictEqual(actual, expected, 'should have returned false because alice committed but did NOT reveal');
     });
 
-    it('should return false for a poll that a voter has NOT committed NOR revealed', async () => {
+    it('should return false for a poll that a voter has NEITHER committed NOR revealed', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();
-      options.actor = alice;
 
-      // alice commits
-      const pollID = await utils.startPollAndCommitVote(options);
-      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+      // start poll
+      const receipt = await plcr.startPoll(options.quorum,
+        options.commitPeriod, options.revealPeriod);
+      const pollID = utils.getPollIDFromReceipt(receipt);
 
-      // alice reveals
-      await utils.as(options.actor, plcr.revealVote, pollID, options.vote, options.salt);
-
-      // didReveal(bob, pollID)
-      const actual = await plcr.didReveal.call(bob, pollID.toString());
+      // didReveal(alice, pollID)
+      const actual = await plcr.didReveal.call(alice, pollID.toString());
       const expected = false;
-      assert.strictEqual(actual, expected, 'should have returned false because bob did NOT reveal');
+      assert.strictEqual(actual, expected, 'should have returned false because alice did NOT reveal');
     });
 
     it('should revert for a poll that doesnt exist', async () => {
       const plcr = await utils.getPLCRInstance();
-      const options = utils.defaultOptions();
-      options.actor = alice;
-
-      // alice commits
-      const pollID = await utils.startPollAndCommitVote(options);
-      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
-
-      // alice reveals
-      await utils.as(options.actor, plcr.revealVote, pollID, options.vote, options.salt);
 
       try {
-        // didReveal(alice, pollID + 420420420)
-        await plcr.didReveal.call(options.actor, pollID.add('420420420').toString());
+        // didReveal(alice, 420420420)
+        await plcr.didReveal.call(alice, '420420420');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
         return;

--- a/test/didReveal.js
+++ b/test/didReveal.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+/* global contract assert */
+
+const utils = require('./utils.js');
+const BN = require('bignumber.js');
+
+contract('PLCRVoting', (accounts) => {
+  describe('Function: didReveal', () => {
+    const [alice, bob] = accounts;
+
+    it('should return true for a poll that a voter has revealed', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+
+      // alice reveals
+      await utils.as(options.actor, plcr.revealVote, pollID, options.vote, options.salt);
+
+      // didReveal(alice, pollID)
+      const actual = await plcr.didReveal.call(options.actor, pollID.toString());
+      const expected = true;
+      assert.strictEqual(actual, expected, 'should have returned true because alice DID reveal');
+    });
+
+    it('should return false for a poll that a voter has committed but NOT revealed', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+
+      // didReveal(alice, pollID)
+      const actual = await plcr.didReveal.call(options.actor, pollID.toString());
+      const expected = false;
+      assert.strictEqual(actual, expected, 'should have returned false because alice committed but did NOT reveal');
+    });
+
+    it('should return false for a poll that a voter has NOT committed NOR revealed', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+
+      // alice reveals
+      await utils.as(options.actor, plcr.revealVote, pollID, options.vote, options.salt);
+
+      // didReveal(bob, pollID)
+      const actual = await plcr.didReveal.call(bob, pollID.toString());
+      const expected = false;
+      assert.strictEqual(actual, expected, 'should have returned false because bob did NOT reveal');
+    });
+
+    it('should revert for a poll that doesnt exist', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // alice commits
+      const pollID = await utils.startPollAndCommitVote(options);
+      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+
+      // alice reveals
+      await utils.as(options.actor, plcr.revealVote, pollID, options.vote, options.salt);
+
+      try {
+        // didReveal(alice, pollID + 420420420)
+        await plcr.didReveal.call(options.actor, pollID.add('420420420').toString());
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+        return;
+      }
+      assert(false, 'should not have been able to successfully call didReveal because the poll doesnt exists');
+    });
+  });
+});


### PR DESCRIPTION
Previously, it was difficult to determine whether a voter had
committed and/or revealed in a poll. One would have to collect all
`_VoteCommitted` and/or `_VoteRevealed` logs to build up the context of
each poll. This commit adds 2 public constant getter functions enabling access to the
`didCommit` and `didReveal` mappings of a poll.

* add public constant functions: `didCommit` & `didReveal`
* add tests