### PR TITLE
Add _TokensRescued event

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -19,7 +19,7 @@ contract PLCRVoting {
     event _PollCreated(uint voteQuorum, uint commitEndDate, uint revealEndDate, uint indexed pollID);
     event _VotingRightsGranted(uint numTokens);
     event _VotingRightsWithdrawn(uint numTokens);
-    event _TokensRescued(uint indexed pollID, address indexed msgSender);
+    event _TokensRescued(uint indexed pollID, address indexed voter);
 
     // ============
     // DATA STRUCTURES:

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -19,6 +19,7 @@ contract PLCRVoting {
     event _PollCreated(uint voteQuorum, uint commitEndDate, uint revealEndDate, uint indexed pollID);
     event _VotingRightsGranted(uint numTokens);
     event _VotingRightsWithdrawn(uint numTokens);
+    event _TokensRescued(uint indexed pollID, address indexed msgSender);
 
     // ============
     // DATA STRUCTURES:
@@ -103,6 +104,7 @@ contract PLCRVoting {
         require(dllMap[msg.sender].contains(_pollID));
 
         dllMap[msg.sender].remove(_pollID);
+        _TokensRescued(_pollID, msg.sender);
     }
 
     // =================


### PR DESCRIPTION
@mnoster has brought this to light: it is difficult to determine if a user has rescued their tokens.

Circumstance:
- user committed
- user did not reveal
- poll expired
- user rescued tokens

This PR adds an event `_TokensRescued` with which a UI can use to check whether a particular user has rescued their tokens