### PR TITLE
Inline requestVotingRights

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -80,7 +80,7 @@ contract PLCRVoting {
         require(token.balanceOf(msg.sender) >= _numTokens);
         voteTokenBalance[msg.sender] += _numTokens;
         require(token.transferFrom(msg.sender, this, _numTokens));
-        _VotingRightsGranted(_numTokens, msg.sender);
+        emit _VotingRightsGranted(_numTokens, msg.sender);
     }
 
     /**
@@ -92,7 +92,7 @@ contract PLCRVoting {
         require(availableTokens >= _numTokens);
         voteTokenBalance[msg.sender] -= _numTokens;
         require(token.transfer(msg.sender, _numTokens));
-        _VotingRightsWithdrawn(_numTokens, msg.sender);
+        emit _VotingRightsWithdrawn(_numTokens, msg.sender);
     }
 
     /**
@@ -104,7 +104,7 @@ contract PLCRVoting {
         require(dllMap[msg.sender].contains(_pollID));
 
         dllMap[msg.sender].remove(_pollID);
-        _TokensRescued(_pollID, msg.sender);
+        emit _TokensRescued(_pollID, msg.sender);
     }
 
     // =================
@@ -150,7 +150,7 @@ contract PLCRVoting {
         store.setAttribute(UUID, "commitHash", uint(_secretHash));
 
         pollMap[_pollID].didCommit[msg.sender] = true;
-        _VoteCommitted(_pollID, _numTokens, msg.sender);
+        emit _VoteCommitted(_pollID, _numTokens, msg.sender);
     }
 
     /**
@@ -192,7 +192,7 @@ contract PLCRVoting {
         dllMap[msg.sender].remove(_pollID); // remove the node referring to this vote upon reveal
         pollMap[_pollID].didReveal[msg.sender] = true;
 
-        _VoteRevealed(_pollID, numTokens, pollMap[_pollID].votesFor, pollMap[_pollID].votesAgainst, _voteOption, msg.sender);
+        emit _VoteRevealed(_pollID, numTokens, pollMap[_pollID].votesFor, pollMap[_pollID].votesAgainst, _voteOption, msg.sender);
     }
 
     /**
@@ -237,7 +237,7 @@ contract PLCRVoting {
             votesAgainst: 0
         });
 
-        _PollCreated(_voteQuorum, commitEndDate, revealEndDate, pollNonce, msg.sender);
+        emit _PollCreated(_voteQuorum, commitEndDate, revealEndDate, pollNonce, msg.sender);
         return pollNonce;
     }
 

--- a/test/commitVote.js
+++ b/test/commitVote.js
@@ -108,7 +108,7 @@ contract('PLCRVoting', (accounts) => {
         'Bob locked tokens by changing his commit');
     });
 
-    it('should revert if the voter\'s voteTokenBalance is less than numTokens', async () => {
+    it('should request for voting rights if voteTokenBalance is less than numTokens', async () => {
       const plcr = await utils.getPLCRInstance();
       const options = utils.defaultOptions();
       options.actor = alice;
@@ -134,10 +134,8 @@ contract('PLCRVoting', (accounts) => {
       try {
         await utils.as(alice, plcr.commitVote, pollID, secretHash, options.numTokens, prevPollID);
       } catch (err) {
-        assert(utils.isEVMException(err), err.toString());
-        return;
+        assert(false, 'voter should have been able to commit more tokens than their balance');
       }
-      assert(false, 'voter was able to commit more tokens than their balance');
     });
 
     it('should revert if pollID is 0', async () => {


### PR DESCRIPTION
`commitVote` requires `msg.sender` to have a `voteTokenBalance` greater than or equal to the number of tokens the `msg.sender` wanted to commit, requiring an additional transaction to be sent before a user could interact with the PLCRVoting contract (3 txns: `token.approve`, `plcr.requestVotingRights`, `plcr.commitVote`).

this PR inlines `requestVotingRights` so that a user can call `commitVote` directly after approval (2 txns) bypassing having to call `requestVotingRights`.