### PR TITLE
v2 features/upgrades

### DIFF
--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -118,7 +118,7 @@ contract PLCRVoting {
     @param _numTokens The number of tokens to be committed towards the target poll
     @param _prevPollID The ID of the poll that the user has voted the maximum number of tokens in which is still less than or equal to numTokens
     */
-    function commitVote(uint _pollID, bytes32 _secretHash, uint _numTokens, uint _prevPollID) external {
+    function commitVote(uint _pollID, bytes32 _secretHash, uint _numTokens, uint _prevPollID) public {
         require(commitPeriodActive(_pollID));
 
         // if msg.sender doesn't have enough voting rights,
@@ -151,6 +151,25 @@ contract PLCRVoting {
 
         pollMap[_pollID].didCommit[msg.sender] = true;
         emit _VoteCommitted(_pollID, _numTokens, msg.sender);
+    }
+
+    /**
+    @notice                 Commits votes using hashes of choices and secret salts to conceal votes until reveal
+    @param _pollIDs         Array of integer identifiers associated with target polls
+    @param _secretHashes    Array of commit keccak256 hashes of voter's choices and salts (tightly packed in this order)
+    @param _numsTokens      Array of numbers of tokens to be committed towards the target polls
+    @param _prevPollIDs     Array of IDs of the polls that the user has voted the maximum number of tokens in which is still less than or equal to numTokens
+    */
+    function commitVotes(uint[] _pollIDs, bytes32[] _secretHashes, uint[] _numsTokens, uint[] _prevPollIDs) external {
+        // make sure the array lengths are all the same
+        require(_pollIDs.length == _secretHashes.length);
+        require(_pollIDs.length == _numsTokens.length);
+        require(_pollIDs.length == _prevPollIDs.length);
+
+        // loop through arrays, committing each individual vote values
+        for (uint i = 0; i < _pollIDs.length; i++) {
+            commitVote(_pollIDs[i], _secretHashes[i], _numsTokens[i], _prevPollIDs[i]);
+        }
     }
 
     /**

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -124,12 +124,12 @@ contract PLCRVoting {
         // if msg.sender doesn't have enough voting rights,
         // request for enough voting rights
         if (voteTokenBalance[msg.sender] < _numTokens) {
-            uint remainder = _numTokens - voteTokenBalance[msg.sender];
+            uint remainder = _numTokens.sub(voteTokenBalance[msg.sender]);
             requestVotingRights(remainder);
         }
 
         // make sure msg.sender has enough voting rights
-        require(voteTokenBalance[msg.sender] >= _numTokens);
+        assert(voteTokenBalance[msg.sender] >= _numTokens);
         // prevent user from committing to zero node placeholder
         require(_pollID != 0);
 

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -129,7 +129,7 @@ contract PLCRVoting {
         }
 
         // make sure msg.sender has enough voting rights
-        assert(voteTokenBalance[msg.sender] >= _numTokens);
+        require(voteTokenBalance[msg.sender] >= _numTokens);
         // prevent user from committing to zero node placeholder
         require(_pollID != 0);
 

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -174,7 +174,7 @@ contract PLCRVoting {
     @param _voteOption Vote choice used to generate commitHash for associated poll
     @param _salt Secret number used to generate commitHash for associated poll
     */
-    function revealVote(uint _pollID, uint _voteOption, uint _salt) external {
+    function revealVote(uint _pollID, uint _voteOption, uint _salt) public {
         // Make sure the reveal period is active
         require(revealPeriodActive(_pollID));
         require(pollMap[_pollID].didCommit[msg.sender]);                         // make sure user has committed a vote for this poll
@@ -193,6 +193,23 @@ contract PLCRVoting {
         pollMap[_pollID].didReveal[msg.sender] = true;
 
         emit _VoteRevealed(_pollID, numTokens, pollMap[_pollID].votesFor, pollMap[_pollID].votesAgainst, _voteOption, msg.sender);
+    }
+
+    /**
+    @notice             Reveals multiple votes with choices and secret salts used in generating commitHashes to attribute committed tokens
+    @param _pollIDs     Array of integer identifiers associated with target polls
+    @param _voteOptions Array of vote choices used to generate commitHashes for associated polls
+    @param _salts       Array of secret numbers used to generate commitHashes for associated polls
+    */
+    function revealVotes(uint[] _pollIDs, uint[] _voteOptions, uint[] _salts) external {
+        // make sure the array lengths are all the same
+        require(_pollIDs.length == _voteOptions.length);
+        require(_pollIDs.length == _salts.length);
+
+        // loop through arrays, revealing each individual vote values
+        for (uint i = 0; i < _pollIDs.length; i++) {
+            revealVote(_pollIDs[i], _voteOptions[i], _salts[i]);
+        }
     }
 
     /**

--- a/test/commitVote.js
+++ b/test/commitVote.js
@@ -114,8 +114,8 @@ contract('PLCRVoting', (accounts) => {
       options.actor = alice;
 
       // calculate a number of tokens greater than the balance
-      const balance = await plcr.voteTokenBalance.call(options.actor);
-      options.numTokens = balance.add('1').toString();
+      const startingBalance = await plcr.voteTokenBalance.call(options.actor);
+      options.numTokens = startingBalance.add('1').toString();
 
       // start a poll
       const receipt = await utils.as(options.actor, plcr.startPoll, options.quorum,
@@ -136,6 +136,11 @@ contract('PLCRVoting', (accounts) => {
       } catch (err) {
         assert(false, 'voter should have been able to commit more tokens than their balance');
       }
+
+      // verify that the ending votingRights balance was increased
+      const endingBalance = await plcr.voteTokenBalance.call(options.actor);
+      assert(endingBalance.toString(), startingBalance.add('1').toString(),
+        'ending balance should have been the starting balance + 1');
     });
 
     it('should revert if pollID is 0', async () => {

--- a/test/commitVotes.js
+++ b/test/commitVotes.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+/* global contract assert */
+
+const utils = require('./utils.js');
+
+contract('PLCRVoting', (accounts) => {
+  describe('Function: commitVotes', () => {
+    const [alice, bob] = accounts;
+
+    it('should commit an array of 1 vote for 1 poll', async () => {
+      const plcr = await utils.getPLCRInstance();
+
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      // start a poll
+      const receipt = await utils.as(options.actor, plcr.startPoll, options.quorum,
+        options.commitPeriod, options.revealPeriod);
+      const pollID = utils.getPollIDFromReceipt(receipt);
+
+      // verify that the commit period is active
+      const isActive = await plcr.commitPeriodActive(pollID);
+      assert(isActive, 'poll\'s commit period is not active');
+
+      // commit an array of 1 vote
+      const secretHash = utils.createVoteHash(options.vote, options.salt);
+      const prevPollID =
+        await plcr.getInsertPointForNumTokens.call(options.actor, options.numTokens, pollID);
+
+      const pollIDs = [pollID];
+      const secretHashes = [secretHash];
+      const numsTokens = [options.numTokens];
+      const prevPollIDs = [prevPollID];
+      try {
+        await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes, numsTokens, prevPollIDs);
+      } catch (err) {
+        assert(false, 'voter should have been able to commit an array of 1 vote');
+      }
+    });
+
+    it('should commit an array of 2 votes for 2 polls', async () => {
+      const plcr = await utils.getPLCRInstance();
+
+      const options1 = utils.defaultOptions();
+      options1.actor = alice;
+      const options2 = utils.defaultOptions();
+      options2.actor = bob;
+
+      // start polls
+      const receipt1 = await utils.as(options1.actor, plcr.startPoll, options1.quorum,
+        options1.commitPeriod, options1.revealPeriod);
+      const receipt2 = await utils.as(options2.actor, plcr.startPoll, options2.quorum,
+        options2.commitPeriod, options2.revealPeriod);
+
+      const pollID1 = utils.getPollIDFromReceipt(receipt1);
+      const pollID2 = utils.getPollIDFromReceipt(receipt2);
+
+      // verify that the commit period is active
+      const isActive1 = await plcr.commitPeriodActive(pollID1);
+      const isActive2 = await plcr.commitPeriodActive(pollID2);
+      assert(isActive1, 'poll1\'s commit period is not active');
+      assert(isActive2, 'poll2\'s commit period is not active');
+
+      // commit an array of 2 votes
+      const secretHash1 = utils.createVoteHash(options1.vote, options1.salt);
+      const prevPollID1 =
+        await plcr.getInsertPointForNumTokens.call(options1.actor, options1.numTokens, pollID1);
+      const secretHash2 = utils.createVoteHash(options2.vote, options2.salt);
+      const prevPollID2 =
+        await plcr.getInsertPointForNumTokens.call(options2.actor, options2.numTokens, pollID2);
+
+      const pollIDs = [pollID1, pollID2];
+      const secretHashes = [secretHash1, secretHash2];
+      const numsTokens = [options1.numTokens, options2.numTokens];
+      const prevPollIDs = [prevPollID1, prevPollID2];
+      try {
+        await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes, numsTokens, prevPollIDs);
+      } catch (err) {
+        assert(false, 'voter should have been able to commit an array of 2 votes');
+      }
+    });
+  });
+});

--- a/test/commitVotes.js
+++ b/test/commitVotes.js
@@ -31,11 +31,7 @@ contract('PLCRVoting', (accounts) => {
       const secretHashes = [secretHash];
       const numsTokens = [options.numTokens];
       const prevPollIDs = [prevPollID];
-      try {
-        await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes, numsTokens, prevPollIDs);
-      } catch (err) {
-        assert(false, 'voter should have been able to commit an array of 1 vote');
-      }
+      await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes, numsTokens, prevPollIDs);
     });
 
     it('should commit an array of 2 votes for 2 polls', async () => {
@@ -61,20 +57,39 @@ contract('PLCRVoting', (accounts) => {
       assert(isActive1, 'poll1\'s commit period is not active');
       assert(isActive2, 'poll2\'s commit period is not active');
 
-      // commit an array of 2 votes
-      const secretHash1 = utils.createVoteHash(options1.vote, options1.salt);
-      const prevPollID1 =
+      // Alice's secretHashes & prevPollIDs
+      const secretHash1a = utils.createVoteHash(options1.vote, options1.salt);
+      const secretHash1b = utils.createVoteHash(options1.vote, options1.salt);
+      const prevPollID1a =
         await plcr.getInsertPointForNumTokens.call(options1.actor, options1.numTokens, pollID1);
-      const secretHash2 = utils.createVoteHash(options2.vote, options2.salt);
-      const prevPollID2 =
+      const prevPollID1b =
+        await plcr.getInsertPointForNumTokens.call(options1.actor, options1.numTokens, pollID2);
+
+      // Bob's secretHashes & prevPollIDs
+      const secretHash2a = utils.createVoteHash(options2.vote, options2.salt);
+      const secretHash2b = utils.createVoteHash(options2.vote, options2.salt);
+      const prevPollID2a =
+        await plcr.getInsertPointForNumTokens.call(options2.actor, options2.numTokens, pollID1);
+      const prevPollID2b =
         await plcr.getInsertPointForNumTokens.call(options2.actor, options2.numTokens, pollID2);
 
+      // Array of poll IDs
       const pollIDs = [pollID1, pollID2];
-      const secretHashes = [secretHash1, secretHash2];
-      const numsTokens = [options1.numTokens, options2.numTokens];
-      const prevPollIDs = [prevPollID1, prevPollID2];
+
+      // Alice's array of: secretHashes, numsTokens, prevPollIDs
+      const secretHashes1 = [secretHash1a, secretHash1b];
+      const numsTokens1 = [options1.numTokens, options1.numTokens];
+      const prevPollIDs1 = [prevPollID1a, prevPollID1b];
+
+      // Bob's array of: secretHashes, numsTokens, prevPollIDs
+      const secretHashes2 = [secretHash2a, secretHash2b];
+      const numsTokens2 = [options2.numTokens, options2.numTokens];
+      const prevPollIDs2 = [prevPollID2a, prevPollID2b];
+
+      // commit an array of 2 votes as Alice and 2 as Bob
       try {
-        await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes, numsTokens, prevPollIDs);
+        await utils.as(alice, plcr.commitVotes, pollIDs, secretHashes1, numsTokens1, prevPollIDs1);
+        await utils.as(bob, plcr.commitVotes, pollIDs, secretHashes2, numsTokens2, prevPollIDs2);
       } catch (err) {
         assert(false, 'voter should have been able to commit an array of 2 votes');
       }

--- a/test/revealVotes.js
+++ b/test/revealVotes.js
@@ -1,0 +1,63 @@
+/* eslint-env mocha */
+/* global contract assert */
+
+const utils = require('./utils.js');
+const BN = require('bignumber.js');
+
+contract('PLCRVoting', (accounts) => {
+  describe('Function: revealVotes', () => {
+    const [alice] = accounts;
+
+    it('should reveal an array of 1 vote', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      const pollID = await utils.startPollAndCommitVote(options);
+
+      const pollIDs = [pollID];
+      const votes = [options.vote];
+      const salts = [options.salt];
+
+      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+      await utils.as(options.actor, plcr.revealVotes,
+        pollIDs, votes, salts);
+
+      const votesFor = await utils.getVotesFor(pollID);
+      const errMsg = 'votesFor should be equal to numTokens';
+      assert.strictEqual(options.numTokens, votesFor.toString(10), errMsg);
+    });
+
+    it('should reveal an array of 2 votes in 2 polls', async () => {
+      const plcr = await utils.getPLCRInstance();
+      const options1 = utils.defaultOptions();
+      options1.actor = alice;
+      options1.vote = '1';
+      options1.salt = '420';
+      const pollID1 = await utils.startPollAndCommitVote(options1);
+
+      const options2 = utils.defaultOptions();
+      options2.actor = alice;
+      options2.vote = '1';
+      options2.salt = '9001';
+      const pollID2 = await utils.startPollAndCommitVote(options2);
+
+      const pollIDs = [pollID1, pollID2];
+      const votes = [options1.vote, options2.vote];
+      const salts = [options1.salt, options2.salt];
+
+      await utils.increaseTime(new BN(options1.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+      await utils.as(options1.actor, plcr.revealVotes,
+        pollIDs, votes, salts);
+
+      const errMsg = 'votesFor should be equal to numTokens';
+
+      const votesFor1 = await utils.getVotesFor(pollID1);
+      assert.strictEqual(options1.numTokens, votesFor1.toString(10), errMsg);
+
+      const votesFor2 = await utils.getVotesFor(pollID2);
+      assert.strictEqual(options2.numTokens, votesFor2.toString(10), errMsg);
+    });
+  });
+});
+


### PR DESCRIPTION
This PR builds on top of #41.

By inlining `requestVotingRights` into `commitVote`, we remove the additional transaction required to commit a vote. Adding functions to commit in multiple polls and reveal multiple committed votes reduces the number of transactions one has to make when sending iterations of similar transactions.

Features:
- [x] inline `requestVotingRights`
- [x] `commitVotes`
- [x] `revealVotes`

Needs more tests