### PR TITLE
Add salt to _VoteRevealed event emission args

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -12,7 +12,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/contracts/PLCRFactory.sol
+++ b/contracts/PLCRFactory.sol
@@ -12,7 +12,7 @@ contract PLCRFactory {
   PLCRVoting public canonizedPLCR;
 
   /// @dev constructor deploys a new canonical PLCRVoting contract and a proxyFactory.
-  constructor() {
+  constructor() public {
     canonizedPLCR = new PLCRVoting();
     proxyFactory = new ProxyFactory();
   }

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -15,7 +15,7 @@ contract PLCRVoting {
     // ============
 
     event _VoteCommitted(uint indexed pollID, uint numTokens, address indexed voter);
-    event _VoteRevealed(uint indexed pollID, uint numTokens, uint votesFor, uint votesAgainst, uint indexed choice, address indexed voter);
+    event _VoteRevealed(uint indexed pollID, uint numTokens, uint votesFor, uint votesAgainst, uint indexed choice, address indexed voter, uint salt);
     event _PollCreated(uint voteQuorum, uint commitEndDate, uint revealEndDate, uint indexed pollID, address indexed creator);
     event _VotingRightsGranted(uint numTokens, address indexed voter);
     event _VotingRightsWithdrawn(uint numTokens, address indexed voter);
@@ -224,7 +224,7 @@ contract PLCRVoting {
         dllMap[msg.sender].remove(_pollID); // remove the node referring to this vote upon reveal
         pollMap[_pollID].didReveal[msg.sender] = true;
 
-        emit _VoteRevealed(_pollID, numTokens, pollMap[_pollID].votesFor, pollMap[_pollID].votesAgainst, _voteOption, msg.sender);
+        emit _VoteRevealed(_pollID, numTokens, pollMap[_pollID].votesFor, pollMap[_pollID].votesAgainst, _voteOption, msg.sender, _salt);
     }
 
     /**

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -45,7 +45,7 @@ contract ProxyFactory {
             proxyAddresses[i] = createProxyImpl(_target, _data);
         }
 
-        ProxiesDeployed(proxyAddresses, _target);
+        emit ProxiesDeployed(proxyAddresses, _target);
     }
 
     function createProxy(address _target, bytes _data)
@@ -54,7 +54,7 @@ contract ProxyFactory {
     {
         proxyContract = createProxyImpl(_target, _data);
 
-        ProxyDeployed(proxyContract, _target);
+        emit ProxyDeployed(proxyContract, _target);
     }
     
     function createProxyImpl(address _target, bytes _data)

--- a/ethpm.json
+++ b/ethpm.json
@@ -1,16 +1,21 @@
 {
   "package_name": "plcr-revival",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PLCR voting for ERC20 tokens",
   "authors": [
     "Yorke Rhodes",
     "Cem Ozer",
-    "Aspyn Palatnick"
+    "Aspyn Palatnick",
+    "Mike Goldin",
+    "Akua Nti",
+    "Kenan O'Neal",
+    "Isaac Kang"
   ],
   "keywords": [
     "tokens",
     "consensys",
-    "plcr"
+    "plcr",
+    "voting"
   ],
   "dependencies": {
     "tokens": "1.0.0",

--- a/test/PLCRVoting/revealVote.js
+++ b/test/PLCRVoting/revealVote.js
@@ -176,6 +176,20 @@ contract('PLCRVoting', (accounts) => {
       const errMsg = 'votesAgainst should be equal to numTokens';
       assert.strictEqual(options.numTokens, votesAgainst.toString(10), errMsg);
     });
+
+    it('should emit the correct salt when a voter reveals a vote', async () => {
+      const options = utils.defaultOptions();
+      options.actor = alice;
+
+      const pollID = await utils.startPollAndCommitVote(options, plcr);
+
+      await utils.increaseTime(new BN(options.commitPeriod, 10).add(new BN('1', 10)).toNumber(10));
+      const receipt = await utils.as(options.actor,
+        plcr.revealVote, pollID, options.vote, options.salt);
+
+      assert.strictEqual(receipt.logs[0].args.salt.toString(), options.salt,
+        'should have emitted the correct salt when revealing a vote');
+    });
   });
 });
 


### PR DESCRIPTION
`claimReward` in its current implementation requires the user to remember their salt even after `revealVote`. this PR exposes the user's salt in an event so that in case a user loses their ticket, a UI can recall a voter's salt after they have revealed.

currently a UI can already do this by interpreting the input data of the reveal transaction. however exposing the salt in an event would require less effort on the frontend.